### PR TITLE
Add Email#charsets reader

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -19,7 +19,8 @@ module Griddler
                 :raw_headers,
                 :attachments,
                 :vendor_specific,
-                :spam_report
+                :spam_report,
+                :charsets
 
     def initialize(params)
       @params = params
@@ -47,6 +48,8 @@ module Griddler
       @vendor_specific = params.fetch(:vendor_specific, {})
 
       @spam_report = params[:spam_report]
+
+      @charsets = params[:charsets]
     end
 
     def to_h
@@ -66,6 +69,7 @@ module Griddler
         vendor_specific: vendor_specific,
         spam_score: spam_score,
         spam_report: spam_report,
+        charsets: charsets
       }
     end
 

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -998,6 +998,13 @@ describe Griddler::Email, 'methods' do
         spam_report: {
           score: 10,
         },
+        charsets: {
+          to: 'UTF-8',
+          html: 'utf-8',
+          subject: 'UTF-8',
+          from: 'UTF-8',
+          text: 'iso-8859-1'
+        }.to_json,
         text: <<-EOS.strip_heredoc.strip
           lololololo hi
 
@@ -1026,6 +1033,7 @@ describe Griddler::Email, 'methods' do
         vendor_specific: {},
         spam_report: email.spam_report,
         spam_score: email.spam_score,
+        charsets: email.charsets
       )
     end
   end


### PR DESCRIPTION
Based on: https://github.com/ygnessin/griddler/pull/4, in tandem with https://github.com/apartmentlist/griddler-sendgrid/pull/1

Allow access to charsets field on Email. This allows for use by
clients in custom parsing of the data later on.